### PR TITLE
Swap synth A & B lock bits

### DIFF
--- a/src/valon_synth.py
+++ b/src/valon_synth.py
@@ -410,7 +410,10 @@ class Synthesizer:
         checksum = self.conn.read(1)
         self.conn.close()
         #_verify_checksum(data, checksum)
-        mask = (synth << 1) or 0x20
+	if synth == SYNTH_A:
+	  mask = 1 << 4
+	else:
+	  mask = 1 << 5
         lock = struct.unpack('>B', data)[0] & mask
         return lock > 0
 


### PR DESCRIPTION
get_phase_lock(synth) had the bit masks
for synths A & B backwards -- get_phase_lock(SYNTH_A)
would return the lock status of SYNTH_B and vice versa.

This commit brings the code in line with the valon register spec.
